### PR TITLE
Fix `Use of undefined constant` Notice

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -130,7 +130,7 @@ class Client extends AbstractClient {
             }
 
             if(in_array($field, ['validFrom', 'validTo'])) {
-                if(newValue !== null && ! $newValue instanceof \DateTime) {
+                if($newValue !== null && ! $newValue instanceof \DateTime) {
                     throw new DisloException('DateTime expected');
                 }
 


### PR DESCRIPTION
`Use of undefined constant` Notice is returned when updating an existing coupon via POST.

Example: `Notice:  Use of undefined constant newValue - assumed 'newValue' in /Users/sarahli/Repos/dislo-coupons/vendor/ixolit/dislo-backend-sdk/src/Client.php on line 133`

Changing newValue to $newValue on line 133 resolves the issue.